### PR TITLE
datapages with permalinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -104,4 +104,4 @@ page_gen:
   - data: 'membros'
     template: 'membro'
     name: 'twitter'
-    dir: 'membro'
+    dir: 'membros'

--- a/plugins/data_page_generator.rb
+++ b/plugins/data_page_generator.rb
@@ -9,8 +9,7 @@ module Jekyll
       @site = site
       @base = base
       @dir = dir
-      @name = sanitize_filename(data[name]) + ".html"
-
+      @name = sanitize_filename(data[name]) + "/index.html"
       self.process(@name)
       self.read_yaml(File.join(base, '_layouts'), template + ".html")
       self.data.merge!(data)
@@ -38,7 +37,7 @@ module Jekyll
           template = data_spec['template'] || data_spec['data']
           name = data_spec['name']
           dir = data_spec['dir'] || data_spec['data']
-          
+
           if site.layouts.key? template
             records =  site.data[data_spec['data']]
             records.each do |record|
@@ -57,7 +56,7 @@ module Jekyll
     # use it like this: {{input | datapage_url: dir}}
     # output: dir / input .html
     def datapage_url(input, dir)
-      dir + "/" + sanitize_filename(input) + ".html"
+      dir + "/" + sanitize_filename(input) + "/index.html"
     end
 
     private
@@ -73,4 +72,3 @@ module Jekyll
 end
 
 Liquid::Template.register_filter(Jekyll::DataPageLinkGenerator)
-

--- a/source/membros/index.markdown
+++ b/source/membros/index.markdown
@@ -11,7 +11,7 @@ A IxDA SP é composta por membros colaboradores voluntários, que dedicam parte 
 <ul class="membros">
   {% for membro in site.data.membros %}
     <li class="membro">
-      <a href="{{ site.url }}/membro/{{ membro.twitter }}.html" title="{{ membro.nome }}">
+      <a href="{{ site.url }}/membros/{{ membro.twitter }}" title="{{ membro.nome }}">
     	  <img src="{{ membro.email | to_gravatar }}" alt="{{ membro.name }}" class="thumbnail" />
     	  <h2 class="nome">{{ membro.nome }}</h2>
       </a>


### PR DESCRIPTION
Adicionei os permalinks na geração de datapages. A página de cada membro agora vai ser gerada em /name/index.html pra poder ser acessada em /membros/twitter_do_membro. 